### PR TITLE
Relax SSL context for plugin.audio.prime_music

### DIFF
--- a/plugin.audio.prime_music/default.py
+++ b/plugin.audio.prime_music/default.py
@@ -15,6 +15,7 @@ import time
 import string
 import random
 import shutil
+import ssl
 import subprocess
 import base64
 import xbmcplugin
@@ -23,6 +24,15 @@ import xbmcaddon
 import xbmcvfs
 from HTMLParser import HTMLParser
 import resources.lib.ScrapeUtils as ScrapeUtils
+
+try:
+    _create_unverified_https_context = ssl._create_unverified_context
+except AttributeError:
+    # Legacy Python that doesn't verify HTTPS certificates by default
+    pass
+else:
+    # Handle target environment that doesn't support HTTPS verification
+    ssl._create_default_https_context = _create_unverified_https_context
 
 addon = xbmcaddon.Addon()
 addonID = addon.getAddonInfo('id')


### PR DESCRIPTION
Das Prime Music Addon scheitert derzeit in LibreELEC daran, dass das CA-Zertifikat für https://music.amazon.de nicht im System hinterlegt ist, woran mechanize bereits beim Öffnen der Amazon-Login-Seite scheitert.
Da LibreELEC auf die CA-Zertifikate zurückgreift, die libressl mitbringt, ist von deren Seite keine Korrektur der Situation zu erwarten.

Dieser PR ermöglicht es dem Prime Music Addon, Zertifikate beliebiger Aussteller zu akzeptieren.

Was mir noch auffiel: Im gesamten Repository herrscht ein Mischmasch aus DOS- und Unix-kodierten Dateien. Für einen guten Editor ist das zwar kein Problem, für Kommandozeilen-Tools aber u.U. schon. Hier wäre eine Vereinheitlichung schön bzw. sinnvoll.