### PR TITLE
Changed Maxdome Addon to 1.0.4.1

### DIFF
--- a/plugin.video.maxdome/addon.xml
+++ b/plugin.video.maxdome/addon.xml
@@ -1,18 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.maxdome" name="maxdome" version="1.0.4.0" provider-name="frankr612">
+<addon id="plugin.video.maxdome" name="maxdome" version="1.0.4.1" provider-name="frankr612, Linkinsoldier">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
 	<import addon="script.module.beautifulsoup" version="3.2.1"/>
     <import addon="script.module.requests" version="2.9.1"/>
-    <import addon="script.module.routing" version="0.2.0"></import>
+    <import addon="script.module.routing" version="0.2.0">
+    <import addon="inputstream.adaptive" version="1.0.8"/>
+    <import addon="script.module.inputstreamhelper" version="0.2.2"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="default.py">
     <provides>video</provides>
   </extension>
   <extension point="xbmc.addon.metadata">
-    <summary lang="de">Maxdome</summary>
-    <description lang="de">Addon für Maxdome Abonnenten</description>
-    <disclaimer lang="de">Achtung: Dies ist kein offizielles Addon und wird von der Maxdome GmbH nicht unterstützt</disclaimer>
+    <summary lang="de">Addon für Maxdome (DE/AT)</summary>
+    <summary lang="en_gb">Addon for Maxdome (DE/AT)</summary>
+    <description lang="de">Addon für Maxdome Abonnenten um Inhalte von Maxdome anzuschauen.
+    
+Warnung an Eltern: Die Maxdome Plattform unterstützt Inhalte inkl. FSK18-Titel.
+
+***Achtung: Dies ist kein offizielles Addon und wird von der Maxdome GmbH nicht unterstützt.***</description>
+    <description lang="en_gb">Addon for Maxdome Subscribers to watch content provided by Maxdome.
+    
+Parental warning: The Maxdome Plattform consists of differnt types of content - including FSK18/PG-R Movies.
+
+***Disclaimer: This is an inofficial Addon and is not made nor supported by Maxdome GmbH.***</description>
+    <disclaimer lang="de">Achtung: Dies ist kein offizielles Addon und wird von der Maxdome GmbH nicht unterstützt.</disclaimer>
+    <disclaimer lang="en_gb">Disclaimer: This is an inofficial Addon and is not made nor supported by Maxdome GmbH.</disclaimer>
     <language></language>
     <platform>all</platform>
     <license></license>

--- a/plugin.video.maxdome/addon.xml
+++ b/plugin.video.maxdome/addon.xml
@@ -4,7 +4,7 @@
     <import addon="xbmc.python" version="2.1.0"/>
 	<import addon="script.module.beautifulsoup" version="3.2.1"/>
     <import addon="script.module.requests" version="2.9.1"/>
-    <import addon="script.module.routing" version="0.2.0">
+    <import addon="script.module.routing" version="0.2.0"/>
     <import addon="inputstream.adaptive" version="1.0.8"/>
     <import addon="script.module.inputstreamhelper" version="0.2.2"/>
   </requires>

--- a/plugin.video.maxdome/changelog.txt
+++ b/plugin.video.maxdome/changelog.txt
@@ -1,3 +1,9 @@
+1.0.4.1
+- Improved Display of "free" (white) and "pay only" content, which will get a "- Buy only" Title addition in Orange (in accordance with Amazon Addon)
+- Introduced Display of users voted for the user rating
+- Added Inputstream and Inputstreamhelper as dependency to improve Inputstream usability
+- Improved Addon Description
+
 1.0.4.0
 - Introduce User Rating and Parental Rating (FSK) into Description/Details
 

--- a/plugin.video.maxdome/maxdome.py
+++ b/plugin.video.maxdome/maxdome.py
@@ -9,7 +9,7 @@ import pickle
 import re
 import HTMLParser
 from BeautifulSoup import BeautifulSoup
-import xbmcaddon, xbmcgui
+import xbmc, xbmcaddon, xbmcgui
 import library as lib
 
 addon = xbmcaddon.Addon()
@@ -120,9 +120,16 @@ class MaxdomeAssets:
             for item in asset_info['packageList']:
                 if 'premium_basic' in item:
                     return True
-
         return False
 
+    def isBuyonly(self, asset_info):
+        # xbmc.log('%s' % (asset_info)) # For Debugging
+        if 'fullMarkingList' in asset_info:
+            for item in asset_info['fullMarkingList']:
+                if 'buyOnly' in item:
+                    return True
+        return False
+        
     def getSalesLabel(self, text):
         if not '<strike>' in text or not '</strike>' in text:
             return text

--- a/plugin.video.maxdome/navigation.py
+++ b/plugin.video.maxdome/navigation.py
@@ -157,6 +157,8 @@ class Navigation:
             r = 'Staffel %02d' % (int(asset['number']))
             if not 'de' in asset['languageList']:
                 r += ' (OV)'
+            if self.mxd.Assets.isBuyonly(asset):
+                r = r + '[COLOR orange] - not included in package[/COLOR]'
             return r
         elif asset_class == 'tvepisode':
             return 'S%02dE%02d - %s' % (int(asset['seasonNumber']), int(asset['episodeNumber']), asset['episodeTitle'])
@@ -272,7 +274,8 @@ class Navigation:
         return listitems
 
     def getInfoItem(self, asset):
-        info = {}
+        # xbmc.log('%s' % (asset)) # For Debugging
+        info = {}      
         info['plot'] = asset['descriptionShort']
         if 'descriptionLong' in asset:
             info['plot'] = asset['descriptionLong']
@@ -284,7 +287,7 @@ class Navigation:
             info['plot'] = '[COLOR red]'+ info['mpaa'] +'[/COLOR]  \n\n' + info['plot']
         if 'userrating' in asset:
             info['rating'] = asset['userrating']['averageRating']
-            info['plot'] = '[COLOR blue]User Rating: '+ str(info['rating']) +' / 5[/COLOR] - ' + info['plot']
+            info['plot'] = '[COLOR blue]' + str(asset['userrating']['countTotal']) +' Users rated: '+ str(info['rating']) +' / 5[/COLOR]  -  ' + info['plot']
         if 'productionYear' in asset:
             info['year'] = asset['productionYear']
         asset_class = maxdome.getAssetClass(asset['@class'])
@@ -311,8 +314,8 @@ class Navigation:
 
         if not asset['green'] and not self.mxd.Assets.isPackageContent(asset):
             if 'title' in info:
-                info['title'] += ' (p)'
-
+                #info['title'] += ' (p)' # old way to separate payed and unpayed content
+                info['title'] = info['title'] + '[COLOR orange] - Buy only[/COLOR]'
         return info
 
     def getPoster(self, data):

--- a/plugin.video.maxdome/resources/settings.xml
+++ b/plugin.video.maxdome/resources/settings.xml
@@ -6,7 +6,7 @@
       <setting id="region" type="labelenum" label="Region" values="DE|AT" default="DE" />
       <setting id="payment" type="labelenum" label="Zahlungsmethode" values="PayPal" default="PayPal" />
 	  <setting id="d51" type="bool" label="Dolby Digital 5.1" default="false" />
-      <setting id="packageonly" type="bool" label="Nur Paketinhalte anzeigen" default="true" />
+      <setting id="packageonly" type="bool" label="Nur Paketinhalte anzeigen" default="false" />
       <setting id="enablelibraryfolder" type="bool" label="In Bibliothek integrieren" default="false" />
       <setting id="customlibraryfolder" type="folder" label="Pfad" enable="eq(-1,true)" default="special://profile/addon_data/plugin.video.maxdome" source="auto" option="writeable" subsetting="true" /> 
   </category>


### PR DESCRIPTION
Changes made:

1.0.4.1
- Improved Display of "free" (white) and "pay only" content, which will get a "- Buy only" Title addition in Orange (in accordance with Amazon Addon)
- Introduced Display of users voted for the user rating
- Added Inputstream and Inputstreamhelper as dependency to improve Inputstream usability
- Improved Addon Description
- Changed "Package only" to false, since it is now perfectly visible in the list