### PR TITLE
Adding Widevine-Check like in Netflix addon etc.

### DIFF
--- a/plugin.video.7tvneu/addon.xml
+++ b/plugin.video.7tvneu/addon.xml
@@ -2,6 +2,7 @@
 <addon id="plugin.video.7tvneu" name="7TV" version="1.0.1" provider-name="L0RE">
 	<requires>
 		<import addon="xbmc.python" version="2.24.0"/>
+		<import addon="script.module.inputstreamhelper" version="0.3.3"/>
 	</requires>
 	<extension point="xbmc.python.pluginsource" library="default.py">
 		<provides>video</provides>

--- a/plugin.video.7tvneu/default.py
+++ b/plugin.video.7tvneu/default.py
@@ -427,10 +427,14 @@ def playvideo(video_id, client_location, source_id=None):
 				data = ul
 		except: data = ul
 	userAgent = 'User-Agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36'
-	listitem = xbmcgui.ListItem(path=data+"|"+userAgent)
-	listitem.setProperty(INPUTSTREAM+".license_type", "com.widevine.alpha")
-	listitem.setProperty(INPUTSTREAM+".manifest_type", "mpd")
-	listitem.setProperty('inputstreamaddon', INPUTSTREAM)
+	
+	import inputstreamhelper
+        is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')
+        if is_helper.check_inputstream():
+		listitem = xbmcgui.ListItem(path=data+"|"+userAgent)
+	    	listitem.setProperty(INPUTSTREAM+".license_type", "com.widevine.alpha")
+		listitem.setProperty(INPUTSTREAM+".manifest_type", "mpd")
+		listitem.setProperty('inputstreamaddon', INPUTSTREAM)
 	try:
 		lic = js3["drm"]["licenseAcquisitionUrl"]
 		token = js3["drm"]["token"]


### PR DESCRIPTION
like in the issue plugin.video.7tvneu - automatic installation of Widevine CDM #89 i've added the widevine helper for using standalone the 7tv addon with DRM protected videos and without installing or using some other addons with intputstreamhelper.