### PR TITLE
Fixed disneychannel episodes

### DIFF
--- a/plugin.video.L0RE.disneychannel/default.py
+++ b/plugin.video.L0RE.disneychannel/default.py
@@ -160,7 +160,7 @@ def playvideo(url):
     debug(jsondata)
     videourl=""
     for element in struct["stack"]:
-        if element["view"]=="watch_3":
+        if element["view"]=="trailer":
            folge=element["data"][0]
            title=folge["title"]
            videourl=folge["embedURL"]


### PR DESCRIPTION
Seit ein paar Tagen ging im Disney Channel Deutschland Addon von L0re das Abspielen von Episoden nicht mehr. Ursache war, dass im JSON Format die Stream URL nun unter Trailer statt Watch3 versteckt.  Es ist die Volle Episode, auch wenn der Knoten im JSON Trailer benannt ist.